### PR TITLE
fix(wake): import json + config-based find_target_window (hermes#22)

### DIFF
--- a/wake.py
+++ b/wake.py
@@ -7,6 +7,7 @@ Slim CLI for post-reload wake. Handles lock acquisition, readiness wait,
 and message sending.
 """
 
+import json
 import sys
 from pathlib import Path
 from chat import send_message, wait_for_chat_ready
@@ -26,23 +27,47 @@ def log(msg):
     print(line, flush=True)
 
 def load_config(path):
+    """Load JSONC config with local overlay. Same pattern as hermes_daemon.load_config."""
     defaults = {
         "wake_msg": "Window reloaded. qhoami",
         "wake_timeout": 30,
+        "session_jsonl": "",
+        "agent_mode": "",
     }
+    def _parse(fpath):
+        raw = Path(fpath).read_text(encoding="utf-8")
+        stripped = "\n".join(l for l in raw.splitlines() if not l.lstrip().startswith("/"))
+        return json.loads(stripped)
     try:
-        raw = Path(path).read_text(encoding="utf-8")
-        return {**defaults, **json.loads(raw)}
-    except Exception:
+        data = _parse(path)
+        merged = {**defaults, **data}
+        local_path = Path(path).parent / "hermes_config.local.jsonc"
+        if local_path.exists():
+            try:
+                merged.update(_parse(local_path))
+            except Exception as le:
+                log(f"[hermes:wake] Local config error: {le} — ignored")
+        # Resolve session_jsonl from autopulse.targets if not set at top level
+        if not merged.get("session_jsonl"):
+            agent_mode = merged.get("agent_mode", "")
+            for t in merged.get("autopulse", {}).get("targets", []):
+                if t.get("agent_mode") == agent_mode:
+                    merged["session_jsonl"] = t.get("session_jsonl", "")
+                    break
+        return merged
+    except Exception as e:
+        log(f"[hermes:wake] Config load error: {e} — using defaults")
         return defaults
 
 def main():
     config = load_config(SCRIPT_DIR / "hermes_config.jsonc")
     message = config["wake_msg"]
     timeout = config["wake_timeout"]
+    session_jsonl = config["session_jsonl"]
+    agent_mode = config["agent_mode"]
 
     with WakeLock():
-        win = find_target_window("session.jsonl", "agent_mode")
+        win = find_target_window(session_jsonl, agent_mode)
         if not win:
             log("No target window found.")
             sys.exit(1)


### PR DESCRIPTION
## What

Two bugs in `wake.py` caused every post-reload wake message to fail silently:

### 1. Missing `import json` in `load_config()`

`json.loads(raw)` raised `NameError: name 'json' is not defined`, caught by bare `except Exception`. Config always fell back to hardcoded defaults. The failure was completely invisible.

### 2. Placeholder strings in `find_target_window`

```python
win = find_target_window("session.jsonl", "agent_mode")
```
Literal placeholder strings — never replaced with actual values. Same bug class as hermes#17 (fixed in PR #19 for `send_message.py`).

## Fix

- Add `import json`
- Replace `load_config()` with daemon-compatible version: JSONC comment stripping + `hermes_config.local.jsonc` overlay
- Resolve `session_jsonl` from `autopulse.targets` if not set directly at top level
- Pass `config["session_jsonl"]` and `config["agent_mode"]` to `find_target_window()`

## Verified

Config loading logic is identical to `hermes_daemon.load_config()` which has been working in production since PR #19.

Closes #22