### PR TITLE
fix(daemon): resolve session_jsonl from targets in poll_once (hermes#24)

### DIFF
--- a/hermes_daemon.py
+++ b/hermes_daemon.py
@@ -539,7 +539,13 @@ def poll_once(state, config, config_path):
 
     # ── Session-anchored window selection for UI triggers (VGM9/hermes#10) ──
     # session_jsonl + agent_mode needed for update-button / reload-dialog only.
-    # If missing (multi-target-only config), skip UI triggers silently.
+    # Resolve session_jsonl from autopulse.targets if not set at top level
+    # (same fallback pattern as wake.py, hermes#22).
+    if not session_jsonl:
+        for t in config.get("autopulse", {}).get("targets", []):
+            if t.get("agent_mode") == agent_mode:
+                session_jsonl = t.get("session_jsonl", "")
+                break
     if not (session_jsonl and agent_mode):
         return config
     target_win = find_target_window(session_jsonl, agent_mode)


### PR DESCRIPTION
Fixes #24.

`poll_once()` in `hermes_daemon.py` read `session_jsonl` only from `autopulse.session_jsonl` (top-level key). With targets-only config (no top-level `session_jsonl`), the update-button and reload-dialog UI triggers were silently skipped every poll cycle.

Applied the same fallback pattern as `wake.py` (hermes#22): walk `autopulse.targets` to find entry matching `agent_mode`, extract `session_jsonl` from it.