### PR TITLE
chore(targets): update polaris1 target notes + add polaris1.status.json

### DIFF
--- a/targets/polaris1.status.json
+++ b/targets/polaris1.status.json
@@ -1,0 +1,17 @@
+{
+  "agent": "POLARIS1",
+  "kq": "0.1.12",
+  "status": "working",
+  "mode": "auto-pilot (departure flag set)",
+  "current_task": "Maintenance — no open backlog items",
+  "last_updated": "2026-02-21",
+  "session_jsonl": "62b28c3c-268d-4efe-9464-99d0247073ef.jsonl",
+  "heartbeat_template": "heartbeat. keep working.",
+  "completed_this_session": [
+    "hermes#24 FIXED: UI triggers skipped with targets-only config (PR #25, bade05d)",
+    "POLARIS3 [B]: HERMES_QUEUE handoff docs in ARCHITECTURE.md (PR #27, fee3b84)",
+    "POLARIS3 [C]: fast_patch_count.py validated on POLARIS1 session — Patch=6 (67db8c0)",
+    "hermes#28/29 FIXED: deliberate sidecar spawn — spawn_sidecar.py (PR #29, 6645d45)"
+  ],
+  "pending_issues": []
+}

--- a/targets/polaris1.target.json
+++ b/targets/polaris1.target.json
@@ -1,9 +1,9 @@
 {
-  "_comment": "POLARIS1 target declaration. Written by POLARIS1 at 0.1.2+. Read by hermes_wake.py.",
+  "_comment": "POLARIS1 target declaration. Written by POLARIS1 at 0.1.2+, confirmed working at 0.1.12+.",
   "agent_mode": "POLARIS1",
   "workspace_name": "agent-hub.code-workspace",
   "window_title_hint": "VGM9",
   "hermes_issue": "https://github.com/VGM9/hermes/issues/6",
   "wake_msg": "Window reloaded. qhoami",
-  "notes": "POLARIS1 runs in the main VGM9 workspace window. The agent-mode-label button reads 'POLARIS1'. This file is a placeholder — POLARIS1 should overwrite it with their actual window_title_hint once confirmed."
+  "notes": "POLARIS1 runs in the main VGM9 workspace (agent-hub.code-workspace). The agent-mode-label button reads 'POLARIS1'. window_title_hint='VGM9' has been stable and confirmed working through thirteen reboots. Session JSONL: 62b28c3c-268d-4efe-9464-99d0247073ef."
 }


### PR DESCRIPTION
## Summary

Two maintenance changes to the `targets/` directory:

### polaris1.target.json
- Removed stale 'placeholder' disclaimer from notes field
- Updated notes to reflect confirmed-working state through 12+ reboots  
- Added `session_jsonl` reference (62b28c3c) for traceability

### polaris1.status.json (new file)
- Mirrors the `polaris3.status.json` pattern
- Documents POLARIS1's session state at end of Twelfth Reboot (kq=0.1.12)
- Records completed work this session, pending_issues=[]

Cleanup only. No functional changes.