### PR TITLE
fix(chat): close foreground-inversion injection bug

### DIFF
--- a/chat/input.py
+++ b/chat/input.py
@@ -40,12 +40,29 @@ def _is_foreground(win) -> bool:
         return False
 
 def wait_for_chat_ready(win, timeout=30):
-    """Block until chat Edit is visible+enabled, or timeout expires."""
+    """Acquire focus on win, then wait until chat Edit is visible+enabled.
+
+    Calls win.set_focus() to bring the window to foreground rather than
+    waiting for the user to do so. Waiting for the user to bring the window
+    to foreground and then injecting is a safety violation: it fires exactly
+    when the user is actively using the target window.
+
+    Returns the Edit control when ready, or None on timeout.
+    """
+    # Acquire focus once at the start. If set_focus fails, bail — we cannot
+    # safely interact with a window we cannot bring to foreground.
+    try:
+        win.set_focus()
+    except Exception:
+        return None
+    time.sleep(0.2)
+
     end = time.time() + timeout
     while time.time() < end:
+        # Safety: if focus was stolen away (user clicked elsewhere), abort.
+        # Do NOT re-steal focus in a loop — that would be harassing the user.
         if not _is_foreground(win):
-            time.sleep(0.5)
-            continue
+            return None  # user took focus back — abort entire wake
         try:
             for edit in win.descendants(control_type="Edit"):
                 name = (edit.element_info.name or "").lower()

--- a/chat/send.py
+++ b/chat/send.py
@@ -6,21 +6,73 @@ chat.send — Message sending utilities
 Provides functions for sending messages via the chat interface.
 """
 
+import ctypes
 import time
 from .input import read_content, clear_input, clipboard_paste, find_send_button, _is_foreground
 
+
+def _get_system_idle_seconds() -> float:
+    """Return seconds since last keyboard or mouse input (system-wide).
+
+    Returns float('inf') on failure so callers fail-open (treat as idle).
+    """
+    try:
+        class LASTINPUTINFO(ctypes.Structure):
+            _fields_ = [("cbSize", ctypes.c_uint), ("dwTime", ctypes.c_uint)]
+        lii = LASTINPUTINFO()
+        lii.cbSize = ctypes.sizeof(LASTINPUTINFO)
+        ctypes.windll.user32.GetLastInputInfo(ctypes.byref(lii))
+        elapsed_ms = ctypes.windll.kernel32.GetTickCount() - lii.dwTime
+        return max(0.0, elapsed_ms / 1000.0)
+    except Exception:
+        return float('inf')
+
+
+# Minimum system idle time required before hermes may inject into ANY window.
+# If the user touched keyboard or mouse within this many seconds, we must not
+# steal focus or paste anything.
+_MIN_SYSTEM_IDLE_SECONDS = 10.0
+
+
 def send_message(win, message, hermes_prefix="[hermes]"):
-    """Type and submit a message into the chat input.
+    """Acquire focus on win and submit a message into the chat input.
+
+    Safety contract:
+      1. Check system-wide idle time first. If the user has touched input
+         in the last _MIN_SYSTEM_IDLE_SECONDS, abort — they are present.
+      2. Acquire focus with set_focus(). This is an intentional focus steal;
+         it must only happen when the user is verifiably idle.
+      3. Re-check system idle after set_focus (covers race where user starts
+         typing while set_focus is in flight).
+      4. Re-check foreground after clipboard paste — before the irrevocable
+         Send action.
 
     Returns:
         True  — delivered
         None  — suppressed: user content in input box (not a failure)
-        False — delivery failure or foreground check failed
+        False — delivery failure, idle check failed, or foreground lost
     """
-    # SAFETY GATE: only operate on the foreground window.
-    # If we are not foreground, we must not touch the input box, paste
-    # into it, or click Send — any of those would corrupt the user's
-    # active work in another window.
+    # INNER IDLE GATE (hermes#41): user must not have touched keyboard/mouse
+    # recently. This is the final safety check before focus acquisition.
+    # The outer autopulse loop already checked system_idle_grace_seconds, but
+    # that check happened at dispatch time — there is a TOCTOU window between
+    # dispatch and execution. This inner gate closes it.
+    if _get_system_idle_seconds() < _MIN_SYSTEM_IDLE_SECONDS:
+        return False  # user is present — do not steal focus
+
+    # Acquire focus explicitly. Never wait for the user to bring the window
+    # to foreground — that would fire on the user at the worst moment.
+    try:
+        win.set_focus()
+    except Exception:
+        return False
+    time.sleep(0.15)  # brief wait for focus to settle
+
+    # Re-check: if user started typing during set_focus(), abort.
+    if _get_system_idle_seconds() < _MIN_SYSTEM_IDLE_SECONDS:
+        return False
+
+    # Verify we actually own the foreground after set_focus.
     if not _is_foreground(win):
         return False
 


### PR DESCRIPTION
## Root cause

The foreground checks in `send_message()` and `wait_for_chat_ready()` were inverted.

`send_message`: `if not _is_foreground(win): return False` → **only fires when user IS in the target window**

`wait_for_chat_ready`: `if not _is_foreground(win): continue` → **waits for user to bring window to foreground, then immediately injects on them**

Both functions fired into windows at the worst possible moment: when the user was actively using them.

## Fix

- `send_message`: inner `GetLastInputInfo` idle check (hermes#41), then explicit `win.set_focus()`, re-check idle to close TOCTOU race, then verify foreground.
- `wait_for_chat_ready`: call `win.set_focus()` once at entry. If user takes focus back, abort — do not re-steal.

Hermes now acquires focus itself when the user is verifiably idle (>10s no keyboard/mouse input) rather than lying in wait to ambush.\n\nCloses #43