### PR TITLE
fix(chat/send): UIA input-focus gate for hermes#41

### DIFF
--- a/chat/input.py
+++ b/chat/input.py
@@ -159,3 +159,36 @@ def find_send_button(win):
         if name in {"send", "send message", "submit"}:
             return btn
     return None
+
+
+# UIA property ID for HasKeyboardFocus — stable across Windows 7+.
+# Source: UI Automation Client Interfaces (MSDN), UIA_HasKeyboardFocusPropertyId.
+_UIA_HasKeyboardFocusPropertyId = 30020
+
+
+def _has_input_focus(win) -> bool:
+    """Return True if the chat input Edit control currently has keyboard focus.
+
+    This detects the 'user is mid-composition' state without stealing or
+    affecting focus in any way. Uses UIA HasKeyboardFocus property query,
+    which is a read-only observation.
+
+    Called by send_message before set_focus() to close the gap where a user
+    pauses mid-composition for >idle_threshold seconds (the system idle gate
+    would pass, but the user is still composing).
+
+    Returns False on any exception — fail-open (assume not composing) to
+    avoid suppressing valid deliveries when UIA enumeration fails.
+    """
+    try:
+        for edit in win.descendants(control_type="Edit"):
+            name = (edit.element_info.name or "").lower()
+            cls = edit.element_info.class_name or ""
+            if "chat input" in name or cls == "native-edit-context":
+                raw = edit.element_info.element.GetCurrentPropertyValue(
+                    _UIA_HasKeyboardFocusPropertyId
+                )
+                return bool(raw)
+    except Exception:
+        pass
+    return False

--- a/chat/send.py
+++ b/chat/send.py
@@ -8,7 +8,7 @@ Provides functions for sending messages via the chat interface.
 
 import ctypes
 import time
-from .input import read_content, clear_input, clipboard_paste, find_send_button, _is_foreground
+from .input import read_content, clear_input, clipboard_paste, find_send_button, _is_foreground, _has_input_focus
 
 
 def _get_system_idle_seconds() -> float:
@@ -59,6 +59,17 @@ def send_message(win, message, hermes_prefix="[hermes]"):
     # dispatch and execution. This inner gate closes it.
     if _get_system_idle_seconds() < _MIN_SYSTEM_IDLE_SECONDS:
         return False  # user is present — do not steal focus
+
+    # INPUT FOCUS GATE (hermes#41 Option 3): check whether the user currently
+    # has keyboard focus in the chat input box. This catches the 'paused
+    # mid-composition' case that the idle gate misses: if the user typed
+    # something, paused for >_MIN_SYSTEM_IDLE_SECONDS, and is still composing
+    # (cursor in the input box), the idle gate would pass but this gate aborts.
+    #
+    # _has_input_focus uses UIA HasKeyboardFocus property read — no focus steal.
+    # Fails-open (returns False) on UIA errors, so suppression is never false.
+    if _has_input_focus(win):
+        return False  # user has cursor in chat input — they are composing
 
     # Acquire focus explicitly. Never wait for the user to bring the window
     # to foreground — that would fire on the user at the worst moment.


### PR DESCRIPTION
Closes #41. Adds _has_input_focus(win) (UIA HasKeyboardFocus property read, no focus steal) called before set_focus() in send_message(). Catches paused-mid-composition case that idle gate misses. Fails-open on UIA error.