### PR TITLE
feat: establish Hermes 1.0 Ralph loop

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "hermes: test v1",
+      "type": "shell",
+      "command": "npm run test:v1",
+      "problemMatcher": [],
+      "group": "test"
+    },
+    {
+      "label": "hermes: dry-run one wake",
+      "type": "shell",
+      "command": "npm run hermes:v1 -- --interval 1 --message \"continue the quest\" --dry-run --max-wakes 1",
+      "problemMatcher": []
+    },
+    {
+      "label": "hermes: queue one wake",
+      "type": "shell",
+      "command": "npm run hermes:v1 -- --interval 1 --message \"continue the quest\" --queue-file .hermes-wake-intents.jsonl --max-wakes 1",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,56 @@
 
 **Priority reading for AI agents working with this codebase.**
 
+## Hermes 1.x Development Rules
+
+The `feature/hermes-1.0-loop-core` branch is the active 1.x development line.
+Do not commit 1.x work directly to `main`. The 0.0.x approval, daemon, and UI
+automation modules remain reference material until a 1.x replacement is
+independently validated.
+
+### Product Boundary
+
+Hermes stimulates the right existing VS Code agent at the right time with the
+right message while getting out of the human's way. The initial 1.x contract is
+only an interval plus a message, followed by a bounded wake attempt. Keep the
+scheduler, target identity, safety policy, and platform delivery separate.
+
+### Human-Safety Requirements
+
+1. Never activate or foreground a window to deliver a wake.
+2. Never type into the user's foreground window or shared keyboard focus.
+3. Never open a visible terminal as part of normal background operation.
+4. Refuse delivery when the target is ambiguous, unverified, foreground-owned,
+   or marked as receiving human input.
+5. Do not claim ambient behavior unless it works while the user is actively
+   using VS Code.
+
+Platform adapters must fail closed when they cannot prove the target and the
+delivery channel are safe. A skipped wake is preferable to a wrong-window
+message or stolen focus.
+
+### Shell and Task Portability
+
+Every executable script and validation command must run in PowerShell, Git Bash,
+and a VS Code task terminal. Prefer `python` over `python3` on Windows and use
+relative repository paths in task arguments. Validate task execution separately
+from direct shell execution. Do not use `node -e`, heredoc programs, or other
+inline application code; create a real script or test file instead.
+
+### Validation Gate
+
+Before committing 1.x work:
+
+```text
+npm run test:v1
+python -m pytest tests/ -m "not requires_vscode" -q
+git -c core.whitespace=cr-at-eol diff --check
+```
+
+Tests must cover the pure decision boundary before any live Windows UI test is
+added. Live UI tests must be opt-in and must never run as part of the default
+test command.
+
 ## Quick Start Guide  
 
 **If you are:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,56 @@
-# HERMES - Agent Approval Automation
+# HERMES - Human-Safe Agent Orchestration
 
-**Detect and manage VSCode chat agent approval requests programmatically.**
+**Stimulate the right VS Code agent at the right time without interrupting the human using the machine.**
+
+Hermes 1.0 begins with a small, deterministic wake loop. It accepts an interval
+and a message, emits at most one wake request per due poll, and leaves delivery
+to an explicitly injected transport. The scheduler itself does not inspect
+windows, move focus, open terminals, or simulate typing.
+
+The existing approval and UI automation code is retained as 0.0.x reference
+material while the 1.0 implementation earns each platform adapter through
+focused tests.
+
+Run the first 1.0 core validation with:
+
+```bash
+npm run test:v1
+```
+
+The executable 1.0 loop accepts only an interval and a wake message. Until a
+platform adapter proves non-focus delivery to an existing chat, use its dry
+run boundary:
+
+```bash
+npm run hermes:v1 -- --interval 300 --message "continue the quest" --dry-run
+```
+
+Add `--max-wakes 1` for a bounded smoke test. Without `--dry-run`, the command
+refuses to start rather than falling back to the legacy focus-stealing UI
+automation.
+
+For a durable, non-invasive handoff to a future trusted relay, use
+`--queue-file path/to/wake-intents.jsonl` instead of `--dry-run`. Queueing is
+not chat delivery; it only records the intent.
+
+The demonstrated live path is available only as an explicit opt-in:
+
+```bash
+python -m hermes_v1.cli --interval 300 \\
+  --message "continue the quest" \\
+  --legacy-live \\
+  --session-jsonl "C:/path/to/chat-session.jsonl" \\
+  --agent-mode "Default Tool Use"
+```
+
+This uses the legacy focus-based sender and is not the unattended-safe
+transport. It must remain opt-in until a non-focus relay is proven.
+
+The project task `hermes: dry-run one wake` runs the bounded smoke test through
+the VS Code task boundary.
+
+The project task `hermes: queue one wake` exercises the durable intent handoff
+through the same boundary.
 
 [![Code Quality](https://img.shields.io/badge/code%20quality-9.5%2F10-success)]()
 [![Pure Functions](https://img.shields.io/badge/pure%20functions-100%25-blue)]()

--- a/hermes_v1/__init__.py
+++ b/hermes_v1/__init__.py
@@ -1,0 +1,19 @@
+"""Hermes 1.0 building blocks."""
+
+from .delivery import DeliveryRefused, SafeWakeTransport, TargetCandidate, select_target
+from .loop import HermesLoop, WakeRequest
+from .legacy_live import LegacyLiveTransport
+from .queue import JsonlWakeQueue
+from .runner import run_loop
+
+__all__ = [
+	"DeliveryRefused",
+	"HermesLoop",
+	"JsonlWakeQueue",
+	"LegacyLiveTransport",
+	"SafeWakeTransport",
+	"TargetCandidate",
+	"WakeRequest",
+	"select_target",
+	"run_loop",
+]

--- a/hermes_v1/cli.py
+++ b/hermes_v1/cli.py
@@ -1,0 +1,104 @@
+"""Command-line boundary for the Hermes 1.0 wake loop."""
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+
+from .loop import WakeRequest
+from .queue import JsonlWakeQueue
+from .runner import run_loop
+
+
+class DryRunTransport:
+    """Print requests without claiming that a real chat wake occurred."""
+
+    def deliver(self, request: WakeRequest) -> None:
+        print(json.dumps(asdict(request), sort_keys=True), flush=True)
+
+
+def non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or greater")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hermes-v1")
+    parser.add_argument("--interval", type=float, required=True)
+    parser.add_argument("--message", required=True)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="emit scheduled requests without delivering to a VS Code chat",
+    )
+    parser.add_argument(
+        "--queue-file",
+        help="persist wake intents as JSONL for a trusted relay",
+    )
+    parser.add_argument(
+        "--legacy-live",
+        action="store_true",
+        help="explicitly use the legacy focus-based live sender",
+    )
+    parser.add_argument("--session-jsonl")
+    parser.add_argument("--agent-mode")
+    parser.add_argument("--max-wakes", type=non_negative_int)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    selected_modes = sum(bool(value) for value in (args.dry_run, args.queue_file, args.legacy_live))
+    if selected_modes > 1:
+        print("select only one delivery mode", file=sys.stderr)
+        return 2
+    if args.legacy_live and not args.session_jsonl:
+        print("--legacy-live requires --session-jsonl", file=sys.stderr)
+        return 2
+    if args.legacy_live and not args.agent_mode:
+        print("--legacy-live requires --agent-mode", file=sys.stderr)
+        return 2
+    if not selected_modes:
+        print(
+            "Hermes 1.0 has no proven non-focus platform transport yet; "
+            "use --dry-run, --queue-file, or explicit --legacy-live.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.dry_run:
+        transport = DryRunTransport()
+    elif args.queue_file:
+        transport = JsonlWakeQueue(args.queue_file)
+    else:
+        from core.ui_automation.window_detection import find_target_window
+        from chat.send import send_message
+        from .legacy_live import LegacyLiveTransport
+
+        transport = LegacyLiveTransport(
+            args.session_jsonl,
+            args.agent_mode,
+            resolver=find_target_window,
+            sender=send_message,
+        )
+    try:
+        run_loop(
+            args.interval,
+            args.message,
+            transport,
+            max_wakes=args.max_wakes,
+            on_delivery_refused=(
+                (lambda error: print(f"wake skipped: {error}", file=sys.stderr))
+                if args.legacy_live
+                else None
+            ),
+        )
+    except KeyboardInterrupt:
+        print("Hermes 1.0 loop stopped", file=sys.stderr)
+        return 130
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_v1/delivery.py
+++ b/hermes_v1/delivery.py
@@ -1,0 +1,74 @@
+"""Safety policy for Hermes 1.0 wake delivery.
+
+This module deliberately contains no Windows UI calls. Platform adapters must
+provide identity resolution and an injection primitive that does not activate a
+window or use the user's foreground keyboard focus.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+from .loop import WakeRequest
+
+
+@dataclass(frozen=True)
+class TargetCandidate:
+    session_id: str
+    window_id: str
+    workspace_root: str
+    identity_verified: bool
+    is_foreground: bool
+    human_input_active: bool
+
+
+class DeliveryRefused(RuntimeError):
+    """The adapter refused delivery because the target was not safe."""
+
+
+class TargetResolver(Protocol):
+    def candidates(self, session_id: str) -> Iterable[TargetCandidate]:
+        ...
+
+
+class MessageInjector(Protocol):
+    def inject_without_activation(
+        self, candidate: TargetCandidate, message: str
+    ) -> None:
+        ...
+
+
+def select_target(
+    candidates: Iterable[TargetCandidate], session_id: str
+) -> TargetCandidate:
+    """Select exactly one verified, non-human-owned target."""
+
+    matches = [candidate for candidate in candidates if candidate.session_id == session_id]
+    if len(matches) != 1:
+        raise DeliveryRefused(
+            f"expected exactly one target for {session_id!r}, found {len(matches)}"
+        )
+    candidate = matches[0]
+    if not candidate.identity_verified:
+        raise DeliveryRefused("target identity is not verified")
+    if candidate.is_foreground:
+        raise DeliveryRefused("target is the user's foreground window")
+    if candidate.human_input_active:
+        raise DeliveryRefused("target has active human input")
+    return candidate
+
+
+class SafeWakeTransport:
+    """Deliver only through an adapter that promises no activation or focus use."""
+
+    def __init__(
+        self, resolver: TargetResolver, injector: MessageInjector, session_id: str
+    ):
+        self._resolver = resolver
+        self._injector = injector
+        self._session_id = session_id
+
+    def deliver(self, request: WakeRequest) -> None:
+        candidate = select_target(
+            self._resolver.candidates(self._session_id), self._session_id
+        )
+        self._injector.inject_without_activation(candidate, request.message)

--- a/hermes_v1/legacy_live.py
+++ b/hermes_v1/legacy_live.py
@@ -1,0 +1,30 @@
+"""Explicit opt-in adapter for the demonstrated legacy live wake path."""
+
+from collections.abc import Callable
+
+from .delivery import DeliveryRefused
+from .loop import WakeRequest
+
+
+class LegacyLiveTransport:
+    """Deliver through legacy window automation only when explicitly selected."""
+
+    def __init__(
+        self,
+        session_jsonl: str,
+        agent_mode: str,
+        *,
+        resolver: Callable[[str, str], object | None],
+        sender: Callable[[object, str], bool],
+    ):
+        self._session_jsonl = session_jsonl
+        self._agent_mode = agent_mode
+        self._resolver = resolver
+        self._sender = sender
+
+    def deliver(self, request: WakeRequest) -> None:
+        target = self._resolver(self._session_jsonl, self._agent_mode)
+        if target is None:
+            raise DeliveryRefused("legacy live target could not be uniquely resolved")
+        if not self._sender(target, request.message):
+            raise DeliveryRefused("legacy live sender refused delivery")

--- a/hermes_v1/loop.py
+++ b/hermes_v1/loop.py
@@ -1,0 +1,58 @@
+"""Pure scheduling core for the Hermes 1.0 wake loop."""
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+
+@dataclass(frozen=True)
+class WakeRequest:
+    """A wake message emitted by the scheduler, before UI delivery."""
+
+    message: str
+    due_at: float
+    sequence: int
+
+
+class WakeTransport(Protocol):
+    """Delivery boundary implemented by a platform-specific adapter."""
+
+    def deliver(self, request: WakeRequest) -> None:
+        ...
+
+
+class HermesLoop:
+    """Emit at most one wake request per polling tick.
+
+    The scheduler has no knowledge of windows, focus, terminals, or UI input.
+    A late poll resets the next deadline instead of emitting a burst of stale
+    messages, which keeps recovery from interrupting a human's work.
+    """
+
+    def __init__(self, interval_seconds: float, message: str, start_at: float):
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be greater than zero")
+        if not message.strip():
+            raise ValueError("message must not be empty")
+        self.interval_seconds = interval_seconds
+        self.message = message
+        self._next_due_at = start_at + interval_seconds
+        self._sequence = 0
+
+    def tick(self, now: float) -> Optional[WakeRequest]:
+        """Return one due request, or ``None`` when the loop is not due."""
+
+        if now < self._next_due_at:
+            return None
+        self._sequence += 1
+        request = WakeRequest(self.message, now, self._sequence)
+        self._next_due_at = now + self.interval_seconds
+        return request
+
+    def tick_and_deliver(self, now: float, transport: WakeTransport) -> bool:
+        """Deliver one due request and report whether delivery was attempted."""
+
+        request = self.tick(now)
+        if request is None:
+            return False
+        transport.deliver(request)
+        return True

--- a/hermes_v1/queue.py
+++ b/hermes_v1/queue.py
@@ -1,0 +1,20 @@
+"""Durable wake-intent handoff for a future trusted platform relay."""
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from .loop import WakeRequest
+
+
+class JsonlWakeQueue:
+    """Append scheduled requests without interacting with windows or input."""
+
+    def __init__(self, path: str | Path):
+        self._path = Path(path)
+
+    def deliver(self, request: WakeRequest) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8", newline="\n") as stream:
+            stream.write(json.dumps(asdict(request), sort_keys=True) + "\n")
+            stream.flush()

--- a/hermes_v1/runner.py
+++ b/hermes_v1/runner.py
@@ -1,0 +1,42 @@
+"""Process runner for the Hermes 1.0 scheduler."""
+
+from collections.abc import Callable
+from time import monotonic, sleep
+
+from .delivery import DeliveryRefused
+from .loop import HermesLoop, WakeTransport
+
+
+def run_loop(
+    interval_seconds: float,
+    message: str,
+    transport: WakeTransport,
+    *,
+    clock: Callable[[], float] = monotonic,
+    sleeper: Callable[[float], None] = sleep,
+    max_wakes: int | None = None,
+    should_stop: Callable[[], bool] = lambda: False,
+    on_delivery_refused: Callable[[DeliveryRefused], None] | None = None,
+) -> int:
+    """Run until stopped or ``max_wakes`` wake requests are delivered."""
+
+    if max_wakes is not None and max_wakes < 0:
+        raise ValueError("max_wakes must not be negative")
+    start_at = clock()
+    loop = HermesLoop(interval_seconds, message, start_at=start_at)
+    delivered = 0
+    while not should_stop() and (max_wakes is None or delivered < max_wakes):
+        now = clock()
+        try:
+            delivered_this_tick = loop.tick_and_deliver(now, transport)
+        except DeliveryRefused as error:
+            if on_delivery_refused is None:
+                raise
+            on_delivery_refused(error)
+            delivered_this_tick = False
+        if delivered_this_tick:
+            delivered += 1
+        elapsed = clock() - now
+        if not should_stop():
+            sleeper(max(0.0, loop.interval_seconds - elapsed))
+    return delivered

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgm9/hermes",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Inter-agent messaging system for VS Code Copilot sessions",
   "type": "module",
   "bin": {
@@ -14,13 +14,15 @@
     "wake":           "python3 ./hermes_wake.py",
     "spawn:sidecar":  "python3 ./spawn_sidecar.py",
     "test":            "python3 -m pytest tests/ -m 'not requires_vscode' -v",
+    "test:v1":          "python -m pytest tests/test_hermes_v1_loop.py tests/test_hermes_v1_delivery.py tests/test_hermes_v1_runner.py tests/test_hermes_v1_cli.py tests/test_hermes_v1_queue.py tests/test_hermes_v1_legacy_live.py -v",
     "test:full":       "python3 -m pytest tests/ -v",
     "deploy-tasks":   "node ./install-tasks.js",
     "postinstall":    "node ./install-tasks.js",
     "reload:phase2":  "python3 ./reload_and_wake.py --phases 2",
     "update:detect":  "python3 ./reload_and_wake.py --phases 0 --detect-only",
     "update:apply":   "python3 ./reload_and_wake.py --phases 0,2",
-    "terminals:kill-all": "node -e \"const {execSync}=require('child_process'); execSync('code-insiders --command workbench.action.terminal.killAll', {stdio:'inherit'})\" || echo 'use qopilot_execute_command(workbench.action.terminal.killAll) from agent'"
+    "terminals:kill-all": "node -e \"const {execSync}=require('child_process'); execSync('code-insiders --command workbench.action.terminal.killAll', {stdio:'inherit'})\" || echo 'use qopilot_execute_command(workbench.action.terminal.killAll) from agent'",
+    "hermes:v1": "python -m hermes_v1.cli"
   },
   "keywords": ["vscode", "copilot", "hermes", "inter-agent", "messaging"],
   "author": "ALTAIR/9 (0.0.Q)",

--- a/scripts/inspect_live_chat_controls.py
+++ b/scripts/inspect_live_chat_controls.py
@@ -1,0 +1,23 @@
+"""Inspect accessible controls in VS Code windows without interaction."""
+
+import sys
+
+from pywinauto import Desktop
+
+
+def main() -> int:
+    sys.stdout.reconfigure(encoding="utf-8")
+    for window in Desktop(backend="uia").windows(visible_only=True):
+        title = window.window_text().strip()
+        if "Visual Studio Code" not in title:
+            continue
+        print(f"WINDOW {title}")
+        for button in window.descendants(control_type="Button"):
+            label = button.window_text().strip()
+            if label:
+                print(f"BUTTON {label}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/list_live_windows.py
+++ b/scripts/list_live_windows.py
@@ -1,0 +1,16 @@
+"""List visible top-level windows without activating them."""
+
+from pywinauto import Desktop
+
+
+def main() -> int:
+    windows = Desktop(backend="uia").windows(visible_only=True)
+    for window in windows:
+        title = window.window_text().strip()
+        if title:
+            print(title)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_live_target.py
+++ b/scripts/probe_live_target.py
@@ -1,0 +1,39 @@
+"""Probe legacy target discovery without delivering input."""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.ui_automation.window_detection import (
+    VSCODE_WINDOW_CLASS_NAME,
+    find_agent_mode_in_window,
+    find_target_window,
+)
+from pywinauto import Desktop
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--session-jsonl", required=True)
+    parser.add_argument("--agent-mode", required=True)
+    args = parser.parse_args()
+    for window in Desktop(backend="uia").windows(visible_only=True):
+        title = window.window_text().strip()
+        if "AO_SLUMBER_BHARTI_AS" in title:
+            print(
+                f"candidate title={title!r} class={window.class_name()!r} "
+                f"agent={find_agent_mode_in_window(window)!r} "
+                f"expected_class={VSCODE_WINDOW_CLASS_NAME!r}"
+            )
+    window = find_target_window(args.session_jsonl, args.agent_mode)
+    if window is None:
+        print("target: NOT_FOUND")
+        return 1
+    print(f"target: FOUND title={window.window_text()!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hermes_v1_cli.py
+++ b/tests/test_hermes_v1_cli.py
@@ -1,0 +1,35 @@
+import pytest
+
+from hermes_v1.cli import main
+
+
+def test_cli_refuses_unproven_real_delivery(capsys):
+    assert main(["--interval", "10", "--message", "continue"]) == 2
+
+    captured = capsys.readouterr()
+    assert "no proven non-focus platform transport" in captured.err
+
+
+def test_cli_refuses_combined_dry_run_and_queue_file(capsys, tmp_path):
+    assert main(
+        [
+            "--interval",
+            "10",
+            "--message",
+            "continue",
+            "--dry-run",
+            "--queue-file",
+            str(tmp_path / "wake.jsonl"),
+        ]
+    ) == 2
+    assert "select only one delivery mode" in capsys.readouterr().err
+
+
+def test_cli_requires_target_identity_for_legacy_live(capsys):
+    assert main(["--interval", "10", "--message", "continue", "--legacy-live"]) == 2
+    assert "requires --session-jsonl" in capsys.readouterr().err
+
+
+def test_cli_rejects_negative_wake_limit():
+    with pytest.raises(SystemExit):
+        main(["--interval", "10", "--message", "continue", "--max-wakes", "-1"])

--- a/tests/test_hermes_v1_delivery.py
+++ b/tests/test_hermes_v1_delivery.py
@@ -1,0 +1,75 @@
+import pytest
+
+from hermes_v1 import DeliveryRefused, SafeWakeTransport, TargetCandidate, WakeRequest
+
+
+class Resolver:
+    def __init__(self, candidates):
+        self._candidates = candidates
+
+    def candidates(self, session_id):
+        return self._candidates
+
+
+class Injector:
+    def __init__(self):
+        self.calls = []
+
+    def inject_without_activation(self, candidate, message):
+        self.calls.append((candidate.window_id, message))
+
+
+def candidate(**overrides):
+    values = {
+        "session_id": "session-a",
+        "window_id": "window-1",
+        "workspace_root": "C:/work/project",
+        "identity_verified": True,
+        "is_foreground": False,
+        "human_input_active": False,
+    }
+    values.update(overrides)
+    return TargetCandidate(**values)
+
+
+def test_transport_delivers_to_one_verified_background_target():
+    injector = Injector()
+    transport = SafeWakeTransport(Resolver([candidate()]), injector, "session-a")
+
+    transport.deliver(WakeRequest("continue", 10, 1))
+
+    assert injector.calls == [("window-1", "continue")]
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ({"is_foreground": True}, "target is the user's foreground window"),
+        ({"human_input_active": True}, "target has active human input"),
+        ({"identity_verified": False}, "target identity is not verified"),
+    ],
+)
+def test_transport_refuses_human_or_unverified_target(overrides, message):
+    injector = Injector()
+    transport = SafeWakeTransport(
+        Resolver([candidate(**overrides)]), injector, "session-a"
+    )
+
+    with pytest.raises(DeliveryRefused, match=message):
+        transport.deliver(WakeRequest("continue", 10, 1))
+
+    assert injector.calls == []
+
+
+def test_transport_refuses_ambiguous_session():
+    injector = Injector()
+    transport = SafeWakeTransport(
+        Resolver([candidate(window_id="one"), candidate(window_id="two")]),
+        injector,
+        "session-a",
+    )
+
+    with pytest.raises(DeliveryRefused, match="exactly one"):
+        transport.deliver(WakeRequest("continue", 10, 1))
+
+    assert injector.calls == []

--- a/tests/test_hermes_v1_legacy_live.py
+++ b/tests/test_hermes_v1_legacy_live.py
@@ -1,0 +1,35 @@
+import pytest
+
+from hermes_v1.delivery import DeliveryRefused
+from hermes_v1.legacy_live import LegacyLiveTransport
+from hermes_v1.loop import WakeRequest
+
+
+def test_legacy_live_transport_sends_only_after_target_resolution():
+    calls = []
+    transport = LegacyLiveTransport(
+        "session.jsonl",
+        "Default Tool Use",
+        resolver=lambda path, mode: calls.append((path, mode)) or "window",
+        sender=lambda window, message: calls.append((window, message)) or True,
+    )
+
+    transport.deliver(WakeRequest("continue", 1, 1))
+
+    assert calls == [
+        ("session.jsonl", "Default Tool Use"),
+        ("window", "continue"),
+    ]
+
+
+@pytest.mark.parametrize("resolved, sent, message", [(None, True, "could not"), ("window", False, "refused")])
+def test_legacy_live_transport_fails_closed(resolved, sent, message):
+    transport = LegacyLiveTransport(
+        "session.jsonl",
+        "Default Tool Use",
+        resolver=lambda path, mode: resolved,
+        sender=lambda window, text: sent,
+    )
+
+    with pytest.raises(DeliveryRefused, match=message):
+        transport.deliver(WakeRequest("continue", 1, 1))

--- a/tests/test_hermes_v1_loop.py
+++ b/tests/test_hermes_v1_loop.py
@@ -1,0 +1,43 @@
+import pytest
+
+from hermes_v1 import HermesLoop
+
+
+class RecordingTransport:
+    def __init__(self):
+        self.requests = []
+
+    def deliver(self, request):
+        self.requests.append(request)
+
+
+def test_loop_emits_one_message_when_interval_is_due():
+    loop = HermesLoop(10, "continue the quest", start_at=100)
+    transport = RecordingTransport()
+
+    assert loop.tick_and_deliver(109.99, transport) is False
+    assert loop.tick_and_deliver(110, transport) is True
+    assert loop.tick_and_deliver(111, transport) is False
+
+    assert [(request.message, request.sequence) for request in transport.requests] == [
+        ("continue the quest", 1)
+    ]
+
+
+def test_late_poll_does_not_emit_a_burst():
+    loop = HermesLoop(10, "one wake", start_at=0)
+
+    assert loop.tick(35).sequence == 1
+    assert loop.tick(35.1) is None
+    assert loop.tick(45) .sequence == 2
+
+
+@pytest.mark.parametrize("interval", [0, -1])
+def test_interval_must_be_positive(interval):
+    with pytest.raises(ValueError, match="interval_seconds"):
+        HermesLoop(interval, "wake", start_at=0)
+
+
+def test_message_must_not_be_blank():
+    with pytest.raises(ValueError, match="message"):
+        HermesLoop(1, "   ", start_at=0)

--- a/tests/test_hermes_v1_queue.py
+++ b/tests/test_hermes_v1_queue.py
@@ -1,0 +1,16 @@
+import json
+
+from hermes_v1.loop import WakeRequest
+from hermes_v1.queue import JsonlWakeQueue
+
+
+def test_jsonl_queue_persists_wake_intent(tmp_path):
+    queue = JsonlWakeQueue(tmp_path / "wake-intents.jsonl")
+
+    queue.deliver(WakeRequest("continue", 12.5, 3))
+
+    assert json.loads((tmp_path / "wake-intents.jsonl").read_text()) == {
+        "due_at": 12.5,
+        "message": "continue",
+        "sequence": 3,
+    }

--- a/tests/test_hermes_v1_runner.py
+++ b/tests/test_hermes_v1_runner.py
@@ -1,0 +1,91 @@
+import pytest
+
+from hermes_v1.delivery import DeliveryRefused
+from hermes_v1.runner import run_loop
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class RecordingTransport:
+    def __init__(self):
+        self.requests = []
+
+    def deliver(self, request):
+        self.requests.append(request)
+
+
+def test_runner_delivers_requested_number_of_wakes():
+    clock = FakeClock()
+    transport = RecordingTransport()
+
+    def advance(seconds):
+        clock.advance(seconds)
+
+    assert run_loop(
+        10,
+        "continue",
+        transport,
+        clock=clock,
+        sleeper=advance,
+        max_wakes=2,
+    ) == 2
+
+    assert [request.sequence for request in transport.requests] == [1, 2]
+    assert [request.message for request in transport.requests] == [
+        "continue",
+        "continue",
+    ]
+
+
+def test_runner_stops_before_scheduling_when_requested():
+    clock = FakeClock()
+    transport = RecordingTransport()
+
+    assert run_loop(
+        10,
+        "continue",
+        transport,
+        clock=clock,
+        sleeper=clock.advance,
+        should_stop=lambda: True,
+    ) == 0
+    assert transport.requests == []
+
+
+def test_runner_rejects_negative_wake_limit():
+    with pytest.raises(ValueError, match="max_wakes"):
+        run_loop(10, "continue", RecordingTransport(), max_wakes=-1)
+
+
+def test_runner_can_retry_refused_delivery():
+    clock = FakeClock()
+    attempts = []
+    transport = RecordingTransport()
+
+    def deliver(request):
+        attempts.append(request.sequence)
+        if len(attempts) == 1:
+            raise DeliveryRefused("busy")
+        transport.requests.append(request)
+
+    transport.deliver = deliver
+
+    assert run_loop(
+        10,
+        "continue",
+        transport,
+        clock=clock,
+        sleeper=clock.advance,
+        max_wakes=1,
+        on_delivery_refused=lambda error: None,
+    ) == 1
+    assert attempts == [1, 2]


### PR DESCRIPTION
## Summary

Establishes the first Hermes 1.0 development increment: an interval/message Ralph loop with bounded retries, explicit target resolution, durable wake-intent queueing, and an opt-in live adapter demonstrated against an existing VS Code chat.

## Branching

This PR targets `devline/hermes-1.0`, which was created from `main`. It is intentionally not a PR to `main`. The 1.0 line will receive multiple review, testing, and merge rounds on the devline before release readiness is considered.

## Included

- Pure scheduler and stoppable runner
- Fail-closed target policy
- JSONL wake-intent handoff
- Explicit `--legacy-live` adapter for the demonstrated existing-chat path
- Dry-run, queue, and VS Code task surfaces
- Focused and non-live test coverage

## Validation

- `npm run test:v1`: 22 passed
- `python.exe -m pytest tests/ -m "not requires_vscode" -q`: 27 passed, 3 deselected
- `git -c core.whitespace=cr-at-eol diff --check`: clean

## Known limitation

The live adapter uses the existing focus-based sender and is explicitly opt-in. It is not yet the unattended-safe non-focus transport. The PR should remain open for review and follow-up rounds.